### PR TITLE
Make icon red if any test has failed

### DIFF
--- a/github-favicon-status.user.js
+++ b/github-favicon-status.user.js
@@ -52,12 +52,16 @@
 
     window.setFavIconAfterStatus = function() {
         var indicator = document.querySelector('.branch-action');
+        indicator = indicator.querySelector('.build-statuses-list');
 
-        // TODO: Read the list of build statuses and determine a status from that.
-        if (indicator && indicator.classList.contains('branch-action-state-clean')) {
-            window.favicon.change(greenGithubIcon);
-        } else if (indicator && indicator.classList.contains('branch-action-state-unstable')) {
+        if (indicator && indicator.querySelector('.text-failure')) {
+            window.favicon.change(redGithubIcon);
+        }
+        else if (indicator && indicator.querySelector('.text-pending')) {
             window.favicon.change(yellowGithubIcon);
+        }
+        else if (indicator && indicator.querySelector('.text-success')) {
+            window.favicon.change(greenGithubIcon);
         }
     };
 


### PR DESCRIPTION
Not sure if there are many version of how github displays Build Statuses and not sure how this works with those if they exists.

<img width="1121" alt="screen shot 2016-05-20 at 13 12 17" src="https://cloud.githubusercontent.com/assets/7257378/15428705/8afce474-1e8c-11e6-8531-e879a3293591.png">

@koddsson 
